### PR TITLE
added event bus with stats for crit count, kill count and damage amount

### DIFF
--- a/global_assets/autoloads/GlobalEventBus.gd
+++ b/global_assets/autoloads/GlobalEventBus.gd
@@ -1,0 +1,31 @@
+extends Node
+
+signal did_damage(amount)
+signal player_did_crit()
+signal enemy_killed()
+
+var damage_done: int
+var kill_count: int
+var player_crit_count: int
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	did_damage.connect(_on_did_damage)
+	enemy_killed.connect(_on_enemy_killed)
+	player_did_crit.connect(_on_player_did_crit)
+	damage_done = 0
+	kill_count = 0
+	player_crit_count = 0
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+func _on_player_did_crit():
+	player_crit_count += 1
+
+func _on_did_damage(amount):
+	damage_done += amount
+
+func _on_enemy_killed():
+	kill_count += 1

--- a/project.godot
+++ b/project.godot
@@ -14,6 +14,10 @@ config/name="ToBeNamed"
 run/main_scene="res://scenes/main_game/main_game.tscn"
 config/features=PackedStringArray("4.2", "Forward Plus")
 
+[autoload]
+
+GlobalEventBus="*res://global_assets/autoloads/GlobalEventBus.gd"
+
 [input]
 
 move_left={

--- a/scenes/enemy/enemy.gd
+++ b/scenes/enemy/enemy.gd
@@ -79,6 +79,8 @@ func _physics_process(delta):
 
 func _on_take_damage(amount, bump_direction, crit):
 	
+	
+	
 	if crit:
 		amount = amount * 2
 	
@@ -87,6 +89,8 @@ func _on_take_damage(amount, bump_direction, crit):
 	get_tree().current_scene.add_child(damagestat_instance)
 	damagestat_instance.emit_damage(amount, crit)
 	
+	var damage_done = clamp(amount,0,Health)
+		
 	Health -= amount
 	HealthBar.set_health(Health)
 	
@@ -102,6 +106,8 @@ func _on_take_damage(amount, bump_direction, crit):
 	tween.parallel().tween_property(Sprite, "modulate", Color.PALE_VIOLET_RED, 0.1).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_OUT)
 	tween.tween_property(Sprite, "modulate", Color.WHITE, 0.1).set_trans(Tween.TRANS_QUAD)
 	
+	# todo make damage not be more than the health left
+	GlobalEventBus.did_damage.emit(damage_done)
 	if Health <= 0:
 		call_deferred("disable_collision")
 		dying = true
@@ -109,6 +115,7 @@ func _on_take_damage(amount, bump_direction, crit):
 		tween = get_tree().create_tween()
 		tween.parallel().tween_property(Sprite, "modulate", Color.TRANSPARENT, 0.25).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
 		tween.tween_callback(queue_free)
+		GlobalEventBus.enemy_killed.emit()
 
 func disable_collision():
 	#did this deferred because 

--- a/scenes/guns/Gun.gd
+++ b/scenes/guns/Gun.gd
@@ -32,6 +32,8 @@ func fire_bullet():
 	instance.velocity = velocity * movement_influence + Vector2(projectile_speed*cos(rotation + PI), projectile_speed*sin(rotation + PI))
 	instance.crit = randi_range(0, 100) < crit_percentage
 	get_tree().current_scene.add_child(instance)
+	if !is_ai_gun and instance.crit:
+		GlobalEventBus.player_did_crit.emit()
 	
 func _input(event):
 	if is_ai_gun:


### PR DESCRIPTION
Made global event bus so that nodes can signal to a single place no matter where in the node tree on events happening. More stats can be stored here but we need to be careful to not get confused on what is sending out the signals, i.e. signal from a gun on an ai vs signal from gun in player